### PR TITLE
Refactor how we fetch supported routes - stop using Redux

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { QuoteResult } from 'routes/operator';
 import { RootState } from 'store';
-import { RouteState } from 'store/transferInput';
 import { isMinAmountError } from 'utils/sdkv2';
 
 type HookReturn = {
@@ -13,7 +12,7 @@ type HookReturn = {
 
 type Props = {
   balance?: sdkAmount.Amount | null;
-  routes: RouteState[];
+  routes: string[];
   quotesMap: Record<string, QuoteResult | undefined>;
   tokenSymbol: string;
   isLoading: boolean;
@@ -56,7 +55,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
     }
 
     return props.routes.every((route) => {
-      return props.quotesMap[route.name]?.success === false;
+      return props.quotesMap[route]?.success === false;
     });
   }, [props.routes, props.quotesMap]);
 

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -1,15 +1,18 @@
-import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { useDebounce } from 'use-debounce';
-
-import { RouteState, setRoutes } from 'store/transferInput';
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import type { RootState } from 'store';
 import config from 'config';
 import { getTokenDetails } from 'telemetry';
 
-const useFetchSupportedRoutes = (): void => {
-  const dispatch = useDispatch();
+type HookReturn = {
+  supportedRoutes: string[];
+  isFetching: boolean;
+};
+
+const useFetchSupportedRoutes = (): HookReturn => {
+  const [routes, setRoutes] = useState<string[]>([]);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
 
   const { token, destToken, fromChain, toChain, amount } = useSelector(
     (state: RootState) => state.transferInput,
@@ -17,18 +20,18 @@ const useFetchSupportedRoutes = (): void => {
 
   const { toNativeToken } = useSelector((state: RootState) => state.relay);
 
-  const [debouncedAmount] = useDebounce(amount, 500);
-
   useEffect(() => {
-    if (!fromChain || !toChain || !token || !destToken || !debouncedAmount) {
-      dispatch(setRoutes([]));
+    if (!fromChain || !toChain || !token || !destToken || !amount) {
+      setRoutes([]);
+      setIsFetching(false);
       return;
     }
 
     let isActive = true;
 
     const getSupportedRoutes = async () => {
-      const routes: RouteState[] = [];
+      setIsFetching(true);
+      const _routes: string[] = [];
       await config.routes.forEach(async (name, route) => {
         let supported = false;
 
@@ -36,7 +39,7 @@ const useFetchSupportedRoutes = (): void => {
           supported = await route.isRouteSupported(
             token,
             destToken,
-            debouncedAmount,
+            amount,
             fromChain,
             toChain,
           );
@@ -53,28 +56,25 @@ const useFetchSupportedRoutes = (): void => {
           console.error('Error when checking route is supported:', e, name);
         }
 
-        routes.push({ name, supported });
+        _routes.push(name);
       });
 
+      setIsFetching(false);
+
       if (isActive) {
-        dispatch(setRoutes(routes));
+        setRoutes(_routes);
       }
     };
 
     getSupportedRoutes();
+  }, [token, destToken, amount, fromChain, toChain, toNativeToken]);
 
-    return () => {
-      isActive = false;
+  return useMemo(() => {
+    return {
+      supportedRoutes: routes,
+      isFetching,
     };
-  }, [
-    dispatch,
-    token,
-    destToken,
-    debouncedAmount,
-    fromChain,
-    toChain,
-    toNativeToken,
-  ]);
+  }, [routes, isFetching]);
 };
 
 export default useFetchSupportedRoutes;

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -63,7 +63,8 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       !params.sourceChain ||
       !params.sourceToken ||
       !params.destChain ||
-      !params.destToken
+      !params.destToken ||
+      routes.length === 0
     ) {
       return;
     }

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -4,7 +4,7 @@ import type { RootState } from 'store';
 import { routes } from '@wormhole-foundation/sdk';
 import useRoutesQuotesBulk from 'hooks/useRoutesQuotesBulk';
 import config from 'config';
-import { RouteState } from 'store/transferInput';
+import useFetchSupportedRoutes from './useFetchSupportedRoutes';
 
 type Quote = routes.Quote<
   routes.Options,
@@ -12,40 +12,26 @@ type Quote = routes.Quote<
 >;
 
 export type RouteWithQuote = {
-  route: RouteState;
+  route: string;
   quote: Quote;
 };
 
 type HookReturn = {
-  allSupportedRoutes: RouteState[];
-  sortedRoutes: RouteState[];
+  allSupportedRoutes: string[];
+  sortedRoutes: string[];
   sortedRoutesWithQuotes: RouteWithQuote[];
   quotesMap: ReturnType<typeof useRoutesQuotesBulk>['quotesMap'];
-  isFetchingQuotes: boolean;
+  isFetching: boolean;
 };
 
 export const useSortedRoutesWithQuotes = (): HookReturn => {
-  const {
-    amount,
-    routeStates,
-    fromChain,
-    token,
-    toChain,
-    destToken,
-    preferredRouteName,
-  } = useSelector((state: RootState) => state.transferInput);
+  const { amount, fromChain, token, toChain, destToken, preferredRouteName } =
+    useSelector((state: RootState) => state.transferInput);
 
   const { toNativeToken } = useSelector((state: RootState) => state.relay);
 
-  const supportedRoutes = useMemo(
-    () => (routeStates || []).filter((rs) => rs.supported),
-    [routeStates],
-  );
-
-  const supportedRoutesNames = useMemo(
-    () => supportedRoutes.map((r) => r.name),
-    [supportedRoutes],
-  );
+  const { supportedRoutes, isFetching: isFetchingSupportedRoutes } =
+    useFetchSupportedRoutes();
 
   const useQuotesBulkParams = useMemo(
     () => ({
@@ -59,15 +45,15 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
     [amount, fromChain, token, toChain, destToken, toNativeToken],
   );
 
-  const { quotesMap, isFetching } = useRoutesQuotesBulk(
-    supportedRoutesNames,
+  const { quotesMap, isFetching: isFetchingQuotes } = useRoutesQuotesBulk(
+    supportedRoutes,
     useQuotesBulkParams,
   );
 
   const routesWithQuotes = useMemo(() => {
     return supportedRoutes
       .map((route) => {
-        const quote = quotesMap[route.name];
+        const quote = quotesMap[route];
         if (quote?.success) {
           return {
             route,
@@ -84,15 +70,15 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
   // Only routes with quotes are sorted.
   const sortedRoutesWithQuotes = useMemo(() => {
     return [...routesWithQuotes].sort((routeA, routeB) => {
-      const routeConfigA = config.routes.get(routeA.route.name);
-      const routeConfigB = config.routes.get(routeB.route.name);
+      const routeConfigA = config.routes.get(routeA.route);
+      const routeConfigB = config.routes.get(routeB.route);
 
       // Prioritize preferred route to avoid flickering the UI
       // when the preferred route gets autoselected
       if (preferredRouteName) {
-        if (routeA.route.name === preferredRouteName) {
+        if (routeA.route === preferredRouteName) {
           return -1;
-        } else if (routeB.route.name === preferredRouteName) {
+        } else if (routeB.route === preferredRouteName) {
           return 1;
         }
       }
@@ -136,8 +122,14 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
       sortedRoutes,
       sortedRoutesWithQuotes,
       quotesMap,
-      isFetchingQuotes: isFetching,
+      isFetching: isFetchingSupportedRoutes || isFetchingQuotes,
     }),
-    [supportedRoutes, sortedRoutesWithQuotes, quotesMap, isFetching],
+    [
+      supportedRoutes,
+      sortedRoutesWithQuotes,
+      quotesMap,
+      isFetchingSupportedRoutes,
+      isFetchingQuotes,
+    ],
   );
 };

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -83,15 +83,9 @@ export type TransferValidations = {
   receiveAmount: ValidationErr;
 };
 
-export type RouteState = {
-  name: string;
-  supported: boolean;
-};
-
 export interface TransferInputState {
   showValidationState: boolean;
   validations: TransferValidations;
-  routeStates: RouteState[] | undefined;
   fromChain: Chain | undefined;
   toChain: Chain | undefined;
   token: string;
@@ -129,7 +123,6 @@ function getInitialState(): TransferInputState {
       relayerFee: '',
       receiveAmount: '',
     },
-    routeStates: undefined,
     fromChain: config.ui.defaultInputs?.fromChain || undefined,
     toChain: config.ui.defaultInputs?.toChain || undefined,
     token: config.ui.defaultInputs?.tokenKey || '',
@@ -228,12 +221,6 @@ export const transferInputSlice = createSlice({
       { payload }: PayloadAction<string>,
     ) => {
       state.route = payload;
-    },
-    setRoutes: (
-      state: TransferInputState,
-      { payload }: PayloadAction<RouteState[]>,
-    ) => {
-      state.routeStates = payload;
     },
     // user input
     setToken: (
@@ -341,14 +328,7 @@ export const transferInputSlice = createSlice({
         state.route = undefined;
         return;
       }
-      if (
-        state.routeStates &&
-        state.routeStates.some((rs) => rs.name === payload && rs.supported)
-      ) {
-        state.route = payload;
-      } else {
-        state.route = undefined;
-      }
+      state.route = payload;
     },
     // clear inputs
     clearTransfer: (state: TransferInputState) => {
@@ -449,7 +429,6 @@ export const selectChain = async (
 export const {
   setValidations,
   setRoute,
-  setRoutes,
   setToken,
   setDestToken,
   setFromChain,

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -252,13 +252,19 @@ export const validate = async (
     transferInput.toChain &&
     transferInput.token &&
     transferInput.destToken &&
-    transferInput.amount &&
+    transferInput.amount !== undefined; /*&&
     transferInput.routeStates?.some((rs) => rs.supported) !== undefined
       ? true
       : false;
+      */
 
   if (!isCanceled()) {
-    dispatch(setValidations({ validations, showValidationState }));
+    dispatch(
+      setValidations({
+        validations,
+        showValidationState: !!showValidationState,
+      }),
+    );
   }
 };
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -127,7 +127,6 @@ const Bridge = () => {
     destToken,
     route,
     preferredRouteName,
-    routeStates,
     supportedDestTokens: supportedDestTokensBase,
     supportedSourceTokens,
     amount,
@@ -139,7 +138,7 @@ const Bridge = () => {
     sortedRoutes,
     sortedRoutesWithQuotes,
     quotesMap,
-    isFetchingQuotes,
+    isFetching: isFetchingQuotes,
   } = useSortedRoutesWithQuotes();
 
   // Compute and set source tokens
@@ -164,20 +163,16 @@ const Bridge = () => {
   // Set selectedRoute if the route is auto-selected
   // After the auto-selection, we set selectedRoute when user clicks on a route in the list
   useEffect(() => {
-    const validRoutes = sortedRoutesWithQuotes.filter(
-      (rs) => rs.route.supported,
-    );
-
-    if (validRoutes.length === 0) {
+    if (sortedRoutesWithQuotes.length === 0) {
       setSelectedRoute('');
     } else {
-      const preferredRoute = validRoutes.find(
-        (route) => route.route.name === preferredRouteName,
+      const preferredRoute = sortedRoutesWithQuotes.find(
+        (route) => route.route === preferredRouteName,
       );
       const autoselectedRoute =
-        route ?? preferredRoute?.route.name ?? validRoutes[0].route.name;
+        route ?? preferredRoute?.route ?? sortedRoutesWithQuotes[0].route;
       const isSelectedRouteValid =
-        validRoutes.findIndex((r) => r.route.name === selectedRoute) > -1;
+        sortedRoutesWithQuotes.findIndex((r) => r.route === selectedRoute) > -1;
 
       // If no route is autoselected or we already have a valid selected route,
       // we should avoid to overwrite it
@@ -185,11 +180,11 @@ const Bridge = () => {
         return;
       }
 
-      const routeData = validRoutes?.find(
-        (rs) => rs.route.name === autoselectedRoute,
+      const routeData = sortedRoutesWithQuotes?.find(
+        (rs) => rs.route === autoselectedRoute,
       );
 
-      if (routeData) setSelectedRoute(routeData.route.name);
+      if (routeData) setSelectedRoute(routeData.route);
     }
   }, [route, sortedRoutesWithQuotes]);
 
@@ -431,11 +426,11 @@ const Bridge = () => {
     amount &&
     !hasError;
 
-  const supportedRouteSelected = useMemo(
+  const supportedRouteSelected = true; /*useMemo(
     () =>
       routeStates?.find?.((rs) => rs.name === selectedRoute && !!rs.supported),
     [routeStates, selectedRoute],
-  );
+  );*/
 
   // Review transaction button is shown only when everything is ready
   const reviewTransactionButton = (


### PR DESCRIPTION
Essentially this change isolates the supported route fetching code inside `useSortedRoutesWithQuotes` hook. There is no longer a global redux value for supported routes, or `RouteStates` type.