### PR TITLE
Add bundle size quality check

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,51 @@
+name: Bundle Size Check
+
+on:
+  pull_request:
+    paths:
+      - 'wormhole-connect/**'
+
+jobs:
+  check-bundle-size:
+    name: Check bundle size
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./wormhole-connect
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ./wormhole-connect/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and analyze bundle
+        run: npm run analyze:ci
+
+      - name: Check bundle sizes
+        run: |
+          MAX_CHUNK_SIZE=$((1024 * 1024)) # 1MB in bytes
+          LARGE_CHUNKS=$(jq -r '.chunks[] | select(.size > '$MAX_CHUNK_SIZE') | "\(.name): \(.size/1024/1024)MB"' stats.json)
+          
+          if [ ! -z "$LARGE_CHUNKS" ]; then
+            echo "::warning ::The following chunks are larger than 1MB:"
+            echo "$LARGE_CHUNKS"
+            echo "Consider code splitting or optimizing these chunks."
+            # In the future, uncomment the following line to make this check fail:
+            # exit 1
+          else
+            echo "All chunks are within size limits!"
+          fi
+
+      - name: Upload bundle stats
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-stats
+          path: wormhole-connect/stats.json

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -77,6 +77,7 @@
     "lint:ci": "scripts/lint_ci.sh",
     "prettier": "prettier --write ./src",
     "analyze": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=6144 vite-bundle-visualizer",
+    "analyze:ci": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=6144 vite-bundle-visualizer --json stats.json",
     "checksdn": "npx tsx scripts/ofac/checkSdnListForUpdates.ts",
     "checkForeignAssets": "npx tsx scripts/checkForeignAssetsConfig.ts",
     "preview": "vite preview",


### PR DESCRIPTION
Implement a GitHub Action to check the bundle size during pull requests, ensuring that no chunks exceed 1MB. This includes adding a new script for analyzing the bundle and updating the package.json with a new command for CI analysis.