### PR TITLE
Fix typo in read-only wallet name

### DIFF
--- a/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
+++ b/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
@@ -10,9 +10,12 @@ import { Chain, chainToChainId, NativeAddress } from '@wormhole-foundation/sdk';
 export class ReadOnlyWallet extends Wallet {
   private _isConnected = true;
 
-  static readonly NAME = 'ReadyOnlyWallet';
+  static readonly NAME = 'ReadOnlyWallet';
 
-  constructor(readonly _address: NativeAddress<Chain>, readonly _chain: Chain) {
+  constructor(
+    readonly _address: NativeAddress<Chain>,
+    readonly _chain: Chain,
+  ) {
     super();
   }
 


### PR DESCRIPTION
## Summary
- fix typo in `ReadOnlyWallet` constant

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684082deb414832fbff0c24092db5630