### PR TITLE
Fix missing 'No routes found' message

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -25,27 +25,30 @@ export const useAmountValidation = (props: Props): HookReturn => {
   // Min amount available
   const minAmount = useMemo(
     () =>
-      Object.values(props.quotes).reduce((minAmount, quoteResult) => {
-        if (quoteResult?.success) {
-          return minAmount;
-        }
+      Object.values(props.quotes).reduce(
+        (minAmount, quoteResult) => {
+          if (quoteResult?.success) {
+            return minAmount;
+          }
 
-        if (!isMinAmountError(quoteResult?.error)) {
-          return minAmount;
-        }
+          if (!isMinAmountError(quoteResult?.error)) {
+            return minAmount;
+          }
 
-        if (!minAmount) {
-          return quoteResult.error.min;
-        }
+          if (!minAmount) {
+            return quoteResult.error.min;
+          }
 
-        const minAmountNum = BigInt(quoteResult.error.min.amount);
-        const existingMin = BigInt(minAmount.amount);
-        if (minAmountNum < existingMin) {
-          return quoteResult.error.min;
-        } else {
-          return minAmount;
-        }
-      }, undefined as sdkAmount.Amount | undefined),
+          const minAmountNum = BigInt(quoteResult.error.min.amount);
+          const existingMin = BigInt(minAmount.amount);
+          if (minAmountNum < existingMin) {
+            return quoteResult.error.min;
+          } else {
+            return minAmount;
+          }
+        },
+        undefined as sdkAmount.Amount | undefined,
+      ),
     [props.quotes],
   );
 
@@ -59,8 +62,12 @@ export const useAmountValidation = (props: Props): HookReturn => {
     });
   }, [props.routes, props.quotes]);
 
+  const noRoutes = useMemo(() => {
+    return props.routes.length === 0;
+  }, [props.routes]);
+
   // Don't show errors when no amount is set or it's loading
-  if (!amount || props.disabled) {
+  if (!amount || props.disabled || props.isLoading) {
     return {};
   }
 
@@ -71,6 +78,12 @@ export const useAmountValidation = (props: Props): HookReturn => {
         error: 'Amount exceeds available balance.',
       };
     }
+  }
+
+  if (noRoutes) {
+    return {
+      error: 'No routes found for this transaction.',
+    };
   }
 
   if (allRoutesFailed) {


### PR DESCRIPTION
## Summary
- detect when no transfer routes exist
- avoid showing errors while quotes are loading

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm install --ignore-scripts` *(fails: 403 Forbidden from npm registry)*


------
https://chatgpt.com/codex/tasks/task_b_6840bd15d1e48326a31ed107a0390f0c